### PR TITLE
Make Superpositeur in-place using sort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(superpositeur
     "${CMAKE_CURRENT_SOURCE_DIR}/src/superpositeur/cli/SuperpositeurCLISession.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/superpositeur/MixedState.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/superpositeur/QuantumOperation.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/superpositeur/SparseVectorSort.cpp"
 )
 
 target_include_directories(superpositeur

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ target_include_directories(superpositeur
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/"
 )
 
+set(TBB_TEST OFF)
+set(TBBMALLOC_BUILD OFF)
 FetchContent_Declare(
   tbb-project
 GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
@@ -72,8 +74,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(superpositeur PRIVATE
         -Wall -Wextra -Werror -Wfatal-errors
         -Wno-error=restrict
-        -fomit-frame-pointer
-        -flto
+        $<$<CONFIG:RELEASE>:-fomit-frame-pointer -flto>
     )
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     target_compile_options(superpositeur PRIVATE
@@ -81,8 +82,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         -Wno-error=unused-but-set-variable
         -Wno-error=unused-function
         -Wno-error=unused-local-typedef
-        -fomit-frame-pointer
-        -flto
+        $<$<CONFIG:RELEASE>:-fomit-frame-pointer -flto>
     )
 elseif(MSVC)
     target_compile_options(superpositeur PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,20 @@ if(NOT SUPERPOSITEUR_CPU_COMPATIBILITY_MODE)
 endif()
 
 #=============================================================================#
+# Instrumentation                                                             #
+#=============================================================================#
+
+option(
+    SUPERPOSITEUR_INSTRUMENTATION
+    "Output some information about runtimes for debugging performance (WIP)"
+    OFF
+)
+
+if(SUPERPOSITEUR_INSTRUMENTATION)
+    target_compile_definitions(superpositeur PUBLIC SUPERPOSITEUR_INSTRU)
+endif()
+
+#=============================================================================#
 # Address sanitizer                                                           #
 #=============================================================================#
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,15 @@ target_include_directories(superpositeur
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/"
 )
 
+FetchContent_Declare(
+  tbb-project
+GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
+GIT_TAG be2fb93722eb973a495c1d5b3661d8768d58d51b
+)
+FetchContent_MakeAvailable(tbb-project)
+
+target_link_libraries(superpositeur PUBLIC tbb)
+
 #=============================================================================#
 # Superpositeur CLI executable                                                #
 #=============================================================================#

--- a/include/superpositeur/Common.hpp
+++ b/include/superpositeur/Common.hpp
@@ -27,4 +27,13 @@ using Hashes = std::vector<std::uint64_t>;
 
 using KrausOperators = std::vector<Matrix>;
 
+
+#ifndef SUPERPOSITEUR_INSTRU
+#define INSTRU \
+if(false) std::cout
+#else 
+#define INSTRU \
+std::cout
+#endif
+
 } // namespace  superpositeur

--- a/include/superpositeur/Common.hpp
+++ b/include/superpositeur/Common.hpp
@@ -22,6 +22,9 @@ struct KeyValue {
 template <std::uint64_t MaxNumberOfQubits>
 using SparseVector = std::vector<KeyValue<MaxNumberOfQubits>>; // Association list.
 
+template <std::uint64_t MaxNumberOfQubits>
+using MatrixOfVectors = std::vector<SparseVector<MaxNumberOfQubits>>;
+
 using Sizes = std::vector<std::uint64_t>;
 using Hashes = std::vector<std::uint64_t>;
 

--- a/include/superpositeur/Matrix.hpp
+++ b/include/superpositeur/Matrix.hpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <random>
 #include <cassert>
+#include <span>
 
 #include "superpositeur/utils/FloatComparison.hpp"
 
@@ -54,6 +55,10 @@ public:
         assert(areValidIndices(i, j));
 
         return data[i * getNumberOfCols() + j];
+    }
+
+    inline std::span<Value const> line(std::uint64_t i) const {
+        return { data.begin() + i * getNumberOfCols(), data.begin() + (i + 1) * getNumberOfCols() };
     }
 
     inline void set(std::uint64_t i, std::uint64_t j, Value v) {

--- a/include/superpositeur/MatrixSparseVectorMultiplication.hpp
+++ b/include/superpositeur/MatrixSparseVectorMultiplication.hpp
@@ -72,8 +72,8 @@ private:
     };
     
     Matrix const& matrix;
-    Input::iterator const begin;
-    Input::iterator const end;
+    typename Input::iterator const begin;
+    typename Input::iterator const end;
     BasisVector<MaxNumberOfQubits> operands;
     std::vector<Iterator> iterators;
 };

--- a/include/superpositeur/MixedState.hpp
+++ b/include/superpositeur/MixedState.hpp
@@ -16,6 +16,7 @@
 #include "superpositeur/utils/FloatComparison.hpp"
 #include "superpositeur/StrongTypes.hpp"
 #include "superpositeur/SparseVectorSort.hpp"
+#include "oneapi/tbb/parallel_sort.h"
 
 namespace superpositeur {
 
@@ -168,7 +169,10 @@ public:
 
         sortSparseVector(data, currentSortIndices.cast<MaxNumberOfQubits>(), negOps);
 
-        // std::sort(std::execution::par, data.begin(), data.end(), [negOps](auto left, auto right) { return (left.ket & negOps) < (right.ket & negOps); });
+        // auto startTimeRegularSort = std::chrono::steady_clock::now();
+        // oneapi::tbb::parallel_sort(data.begin(), data.end(), [negOps](auto left, auto right) { return (left.ket & negOps) < (right.ket & negOps); });
+        // auto endTimeRegularSort = std::chrono::steady_clock::now();
+        // INSTRU << "regularSort," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTimeRegularSort - startTimeRegularSort).count() << "," << negOps << std::endl;
 
         auto startTime = std::chrono::steady_clock::now();
         auto originalDataSize = data.size();

--- a/include/superpositeur/MixedState.hpp
+++ b/include/superpositeur/MixedState.hpp
@@ -168,6 +168,11 @@ public:
 
         sortSparseVector(data, currentSortIndices.cast<MaxNumberOfQubits>(), negOps);
 
+        // std::sort(std::execution::par, data.begin(), data.end(), [negOps](auto left, auto right) { return (left.ket & negOps) < (right.ket & negOps); });
+
+        auto startTime = std::chrono::steady_clock::now();
+        auto originalDataSize = data.size();
+
         SparseVector<MaxNumberOfQubits> d;
         auto it = data.begin();
         auto max = data.end();
@@ -217,7 +222,17 @@ public:
             d.clear();
         }
 
+        auto endTime = std::chrono::steady_clock::now();
+
+        INSTRU << "applyGate," << originalDataSize << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << std::endl;
+
+        startTime = std::chrono::steady_clock::now();
+
         std::inplace_merge(data.begin(), max, data.end(), [negOps](auto const left, auto const right) { return (left.ket & negOps) < (right.ket & negOps); });
+
+        endTime = std::chrono::steady_clock::now();
+
+        INSTRU << "finalInplaceMerge," << originalDataSize << "," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << std::endl;
 
         assert(std::is_sorted(data.begin(), data.end(), [negOps](auto const left, auto const right) {
             return (left.ket & negOps) < (right.ket & negOps);

--- a/include/superpositeur/MixedState.hpp
+++ b/include/superpositeur/MixedState.hpp
@@ -16,24 +16,23 @@
 #include "superpositeur/utils/FloatComparison.hpp"
 #include "superpositeur/StrongTypes.hpp"
 #include "superpositeur/SparseVectorSort.hpp"
-#include "oneapi/tbb/parallel_sort.h"
 
 namespace superpositeur {
 
 class MixedState {
 public:
-    explicit MixedState() : currentSortIndices(~BasisVector<128>()), dataVariant(SparseVector<64>{{BasisVector<64>{}, 1.}}), sizes({1}), hashes({0}) {}
+    explicit MixedState() : currentSortIndices(~BasisVector<128>()), dataVariant(MatrixOfVectors<64>{ SparseVector<64>{{BasisVector<64>{}, 1.}} }), hashes({BasisVector<64>{}.hash()}) {}
 
     void reset() {
-        dataVariant = SparseVector<64>{{BasisVector<64>{}, 1.}};
-        sizes = {1};
-        hashes = {0};
+        dataVariant = MatrixOfVectors<64>{ SparseVector<64>{{BasisVector<64>{}, 1.}} };
+        hashes = {BasisVector<64>{}.hash()};
     }
 
     std::uint64_t currentSize() const {
-        return std::visit([](auto const& data) { return std::remove_reference<decltype(data)>::type::value_type::MAX_NUMBER_OF_BITS; }, dataVariant);
+        return std::visit([](auto const& data) { return std::remove_reference<decltype(data)>::type::value_type::value_type::MAX_NUMBER_OF_BITS; }, dataVariant);
     }
 
+public:
     template <std::uint64_t NumberOfQubits>
     void resize() {
         static_assert(NumberOfQubits % 64 == 0); // FIXME
@@ -49,20 +48,19 @@ public:
     void simplify() {
         // TODO: assert equality before/after simplification.
 
-        if (sizes.size() <= 1) {
-            return;
-        }
-
         std::visit([&](auto &data) {
+            if (data.size() <= 1) {
+                return;
+            }
+
             simplifyImpl(data);
         }, dataVariant);
     }
 
 private:
-    // FIXME: use std::dequeue, no needs for "lines" to be local var in simplify
     template <std::uint64_t MaxNumberOfQubits>
-    void insertOrApply(std::vector<std::span<KeyValue<MaxNumberOfQubits>>>& lines, std::unordered_map<std::uint64_t, std::uint64_t>& hashToIndex, std::uint64_t index1) {
-        if (lines[index1].empty()) {
+    void insertOrApply(MatrixOfVectors<MaxNumberOfQubits>& matrixOfVectors, std::unordered_map<std::uint64_t, std::uint64_t>& hashToIndex, std::uint64_t index1) {
+        if (matrixOfVectors[index1].empty()) {
             return;
         }
 
@@ -78,57 +76,42 @@ private:
         assert(hash2 == it->first);
         assert(hash1 == hash2);
 
-        applyGivensRotation<MaxNumberOfQubits>(lines[index1], hash1, lines[index2], hash2);
+        applyGivensRotation<MaxNumberOfQubits>(matrixOfVectors[index1], hash1, matrixOfVectors[index2], hash2);
 
         if (hash2 == it->first) [[likely]] {
-            insertOrApply(lines, hashToIndex, index1);
+            insertOrApply(matrixOfVectors, hashToIndex, index1);
             return;
         }
 
         hashToIndex.erase(it);
-        insertOrApply(lines, hashToIndex, index1);
-        insertOrApply(lines, hashToIndex, index2);
+        insertOrApply(matrixOfVectors, hashToIndex, index1);
+        insertOrApply(matrixOfVectors, hashToIndex, index2);
     }
 
 public:
 
     template <std::uint64_t MaxNumberOfQubits>
-    void simplifyImpl(SparseVector<MaxNumberOfQubits> &data) {
-        std::vector<std::span<KeyValue<MaxNumberOfQubits>>> lines;
-        lines.reserve(sizes.size());
-    
-        auto it = data.begin();
-        for (auto s: sizes) {
-            assert(it < data.end());
-            assert(static_cast<std::uint64_t>(std::distance(it, data.end())) >= s);
-            auto next = std::next(it, s);
-            lines.emplace_back(it, next);
-            it = next;
-        }
-
+    void simplifyImpl(MatrixOfVectors<MaxNumberOfQubits> &data) {
         std::unordered_map<std::uint64_t, std::uint64_t> hashToIndex;
 
         for (std::uint64_t i = 0; i < hashes.size(); ++i) {
-            insertOrApply(lines, hashToIndex, {i});
+            insertOrApply(data, hashToIndex, {i});
         }
 
-        SparseVector<MaxNumberOfQubits> newData;
-        newData.reserve(data.size());
-        sizes.clear();
-        hashes.clear();
-        for (auto const& [hash, index]: hashToIndex) {
-            auto const& line = lines[index];
-            sizes.push_back(line.size());
-            hashes.push_back(hash);
-            newData.insert(newData.end(), line.begin(), line.end());
+        auto it = data.begin();
+        auto hashesIt = hashes.begin();
+        while (it != data.end()) {
+            if (it->empty()) {
+                it = data.erase(it);
+                hashesIt = hashes.erase(hashesIt);
+            } else {
+                ++it;
+                ++hashesIt;
+            }
         }
-
-        data.swap(newData);
     }
 
     void operator()(CircuitInstruction const &circuitInstruction) {
-        simplify();
-
         auto bitWidth = circuitInstruction.getOperandsMask().bitWidth();
         if (bitWidth > currentSize()) {
             if (bitWidth <= 128) {
@@ -142,37 +125,17 @@ public:
             applyCircuitInstruction(circuitInstruction, data);
         }, dataVariant);
         
+        simplify();
 
         assert(isConsistent());
     }
 
+private:
     template <std::uint64_t MaxNumberOfQubits>
-    void applyCircuitInstruction(CircuitInstruction const &circuitInstruction, SparseVector<MaxNumberOfQubits>& data) {
-        if (!circuitInstruction.getControlQubitsMask().empty()) {
-            throw std::runtime_error("Unimplemented: control qubits");
-        }
-
-        if (circuitInstruction.getKrausOperators().size() > 1) {
-            throw std::runtime_error("Unimplemented: Kraus");
-        }
-
-        auto const matrix = circuitInstruction.getKrausOperators()[0];
-
-        auto ops = circuitInstruction.getOperandsMask().cast<MaxNumberOfQubits>(); // FIXME
-        auto nOps = circuitInstruction.getOperandsMask().popcount();
-
-        if (nOps > 2) {
-            throw std::runtime_error("Unimplemented: 3+ ops");
-        }
-        
-        auto negOps = ~ops;
-
-        sortSparseVector(data, currentSortIndices.cast<MaxNumberOfQubits>(), negOps);
-
-        // auto startTimeRegularSort = std::chrono::steady_clock::now();
-        // oneapi::tbb::parallel_sort(data.begin(), data.end(), [negOps](auto left, auto right) { return (left.ket & negOps) < (right.ket & negOps); });
-        // auto endTimeRegularSort = std::chrono::steady_clock::now();
-        // INSTRU << "regularSort," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTimeRegularSort - startTimeRegularSort).count() << "," << negOps << std::endl;
+    std::uint64_t applyMatrixToSparseVector(SparseVector<MaxNumberOfQubits>& data, Matrix const& matrix, BasisVector<MaxNumberOfQubits> const& operands) {
+        assert(std::is_sorted(data.begin(), data.end(), [operands](auto const left, auto const right) {
+            return (left.ket & (~operands)) < (right.ket & (~operands));
+        }));
 
         auto startTime = std::chrono::steady_clock::now();
         auto originalDataSize = data.size();
@@ -180,33 +143,35 @@ public:
         std::vector<std::complex<double>> inputVector;
         inputVector.resize(matrix.getNumberOfRows());
 
+        std::uint64_t newHash = 0;
+
         auto it = data.begin();
         auto max = data.end();
         while (it != max) {
             auto firstKey = it->ket;
-            auto rest = firstKey & negOps;
+            auto rest = firstKey & (~operands);
 
             std::fill(inputVector.begin(), inputVector.end(), 0.);
 
             auto end = it;
-            while (end != max && (end->ket & negOps) == rest) {
-                inputVector[end->ket.pext(ops)] = end->amplitude;
+            while (end != max && (end->ket & (~operands)) == rest) {
+                inputVector[end->ket.pext(operands)] = end->amplitude;
                 ++end;
             }
 
             for (std::uint64_t i = 0; i < matrix.getNumberOfRows(); ++i) {
                 auto v = std::inner_product(inputVector.begin(), inputVector.end(), matrix.line(i).begin(), std::complex<double>(0.));
-                auto key = firstKey.pdep(i, ops);
+                auto key = firstKey.pdep(i, operands);
 
                 if (utils::isNotNull(v)) {
                     if (it == end) {
                         if (data.size() < data.capacity()) [[likely]] {
-                            data.emplace_back(key, v);
+                            data.push_back({key, v});
                         } else {
                             auto itDist = std::distance(data.begin(), it);
                             auto endDist = std::distance(data.begin(), end);
                             auto maxDist = std::distance(data.begin(), max);
-                            data.emplace_back(key, v);
+                            data.push_back({key, v});
                             it = std::next(data.begin(), itDist);
                             end = std::next(data.begin(), endDist);
                             max = std::next(data.begin(), maxDist);
@@ -215,10 +180,14 @@ public:
                         *it = { key, v };
                         ++it;
                     }
+
+                    newHash += key.hash();
                 }
             }
 
+            std::uint64_t maxDist = static_cast<std::uint64_t>(std::distance(data.begin(), max));
             it = data.erase(it, end);
+            max = std::next(data.begin(), std::min(data.size(), maxDist));
         }
 
         auto endTime = std::chrono::steady_clock::now();
@@ -227,28 +196,77 @@ public:
 
         startTime = std::chrono::steady_clock::now();
 
-        std::inplace_merge(data.begin(), max, data.end(), [negOps](auto const left, auto const right) { return (left.ket & negOps) < (right.ket & negOps); });
+        std::inplace_merge(data.begin(), max, data.end(), [negOps = ~operands](auto const left, auto const right) { return (left.ket & negOps) < (right.ket & negOps); });
 
         endTime = std::chrono::steady_clock::now();
 
         INSTRU << "finalInplaceMerge," << originalDataSize << "," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << std::endl;
 
-        assert(std::is_sorted(data.begin(), data.end(), [negOps](auto const left, auto const right) {
+        assert(std::is_sorted(data.begin(), data.end(), [negOps = ~operands](auto const left, auto const right) {
             return (left.ket & negOps) < (right.ket & negOps);
         }));
 
-        sizes[0] = data.size(); // FIXME: to pass the assert
+        return newHash;
+    }
+
+public:
+    template <std::uint64_t MaxNumberOfQubits>
+    void applyCircuitInstruction(CircuitInstruction const &circuitInstruction, MatrixOfVectors<MaxNumberOfQubits>& data) {
+        if (!circuitInstruction.getControlQubitsMask().empty()) {
+            throw std::runtime_error("Unimplemented: control qubits");
+        }
+
+        auto ops = circuitInstruction.getOperandsMask().cast<std::remove_reference<decltype(data)>::type::value_type::value_type::MAX_NUMBER_OF_BITS>();
+
+        std::for_each(data.begin(), data.end(), [&](auto& v) {
+            sortSparseVector(v, currentSortIndices.cast<MaxNumberOfQubits>(), ~ops);
+        });
+
+        auto originalNumberOfVectors = data.size();
+        data.reserve(circuitInstruction.getKrausOperators().size() * originalNumberOfVectors);
+        for (std::uint64_t i = 1; i < circuitInstruction.getKrausOperators().size(); ++i) {
+            data.insert(data.end(), data.begin(), data.begin() + originalNumberOfVectors);
+        }
+
+        hashes.resize(data.size()); // Values don't matter here.
+
+        for (std::uint64_t krausOperatorIndex = 0; krausOperatorIndex < circuitInstruction.getKrausOperators().size(); ++krausOperatorIndex) {
+            auto const& matrix = circuitInstruction.getKrausOperators()[krausOperatorIndex];
+            
+            for (std::uint64_t i = originalNumberOfVectors * krausOperatorIndex; i < originalNumberOfVectors * (krausOperatorIndex + 1); ++i) {
+                assert(i < data.size());
+
+                hashes[i] = applyMatrixToSparseVector(data[i], matrix, ops);
+            }
+        }
+
         currentSortIndices = ~circuitInstruction.getOperandsMask();
     }
 
 private:
+    template <std::uint64_t N>
+    static BasisVector<N> getMask(std::vector<bool> v) {
+        BasisVector<N> mask;
+        for (std::uint64_t i = 0; i < v.size(); ++i) {
+            mask.set(i, v[i]);
+        }
+        return mask;
+    }
+
     struct ReducedDensityMatrixIterator {
         using Value = std::tuple<std::uint64_t, std::uint64_t, std::complex<double>>; // i, j, M[i, j]
 
         template <std::uint64_t N>
-        ReducedDensityMatrixIterator(SparseVector<N> const& data, Sizes const& sizes, std::vector<bool> mask) :
-            internalsVariant(Internals<N>{.end = data.begin() + sizes[0], .it1 = data.begin(), .it2 = data.begin(), .reductionQubits = getMask<N>(mask)}),
-            sizesIterator(sizes.begin()), sizesEnd(sizes.end()) {}
+        ReducedDensityMatrixIterator(MatrixOfVectors<N>& data, std::vector<bool>& mask) :
+            internalsVariant(Internals<N>{.data = data, .reductionQubits = getMask<N>(mask), .vectorIterator = data.begin(), .it1 = data[0].begin(), .it2 = data[0].begin()}) {
+            
+            assert(std::all_of(data.begin(), data.end(), [sortIndices = ~getMask<N>(mask)](auto const& v) {
+                return std::is_sorted(v.begin(), v.end(), [sortIndices](auto const left, auto const right) {
+                    return (left.ket & sortIndices) < (right.ket & sortIndices);
+                });
+            }));
+            // Let op! There can be only one density matrix iterator operating at once! And any gate application will invalidate it!
+        }
 
         // Should this own shared ownership of data?
 
@@ -257,44 +275,35 @@ private:
         }
 
     private:
-        template <std::uint64_t N>
-        static BasisVector<N> getMask(std::vector<bool> v) {
-            BasisVector<N> mask;
-            for (std::uint64_t i = 0; i < v.size(); ++i) {
-                mask.set(i, v[i]);
-            }
-            return mask;
-        }
-
         template <typename Internals>
         std::optional<Value> nextImpl(Internals& internals) {
-            assert(internals.it1 <= internals.it2);
-
-            if (internals.it1 == internals.end) {
-                assert(internals.it1 == internals.it2);
-
-                if (sizesIterator == sizesEnd || ++sizesIterator == sizesEnd) {
-                    return std::nullopt;
-                }
-
-                assert(*sizesIterator != 0);
-                internals.end += *sizesIterator;
+            if (internals.vectorIterator == internals.data.end()) {
+                return std::nullopt;
             }
-            
-            assert(sizesIterator != sizesEnd && *sizesIterator > 0);
-            assert(internals.it2 != internals.end);
+
+            assert(internals.it1 != internals.vectorIterator->end());
+            assert(internals.it2 != internals.vectorIterator->end());
+            assert(internals.it1 <= internals.it2);
             assert((internals.it1->ket & (~internals.reductionQubits)) == (internals.it2->ket & (~internals.reductionQubits)));
 
             Value result = Value(internals.it1->ket.pext(internals.reductionQubits), internals.it2->ket.pext(internals.reductionQubits), internals.it1->amplitude * std::conj(internals.it2->amplitude));
 
-            auto current = internals.it1->ket & (~internals.reductionQubits);
-            do {
-                ++internals.it2;
-            } while (internals.it2 != internals.end && ((internals.it2->ket & (~internals.reductionQubits)) != current));
-
-            if (internals.it2 == internals.end) {
-                ++internals.it1;
-                internals.it2 = internals.it1;
+            if (std::next(internals.it2) == internals.vectorIterator->end()) {
+                if (std::next(internals.it1) == internals.vectorIterator->end()) {
+                    ++internals.vectorIterator;
+                    internals.it1 = internals.vectorIterator->begin();
+                    internals.it2 = internals.vectorIterator->begin();
+                } else {
+                    ++internals.it1;
+                    internals.it2 = internals.it1;
+                }
+            } else {
+                if ((std::next(internals.it2)->ket & (~internals.reductionQubits)) == (internals.it1->ket & (~internals.reductionQubits))) {
+                    ++internals.it2;
+                } else {
+                    ++internals.it1;
+                    internals.it2 = internals.it1;
+                }
             }
 
             return result;
@@ -302,83 +311,87 @@ private:
 
         template <std::uint64_t N>
         struct Internals {
-            typename SparseVector<N>::const_iterator end;
-            typename SparseVector<N>::const_iterator it1;
-            typename SparseVector<N>::const_iterator it2;
+            MatrixOfVectors<N> const& data;
             BasisVector<N> reductionQubits;
+            typename MatrixOfVectors<N>::iterator vectorIterator;
+            typename SparseVector<N>::iterator it1;
+            typename SparseVector<N>::iterator it2;
         };
 
         std::variant<Internals<64UL>, Internals<128UL>> internalsVariant;
-
-        Sizes::const_iterator sizesIterator;
-        Sizes::const_iterator const sizesEnd;
     };
 
     struct ReducedDensityMatrixDiagonalIterator {
         using Value = std::pair<std::uint64_t, double>; // i, M[i, i]
 
         template <std::uint64_t N>
-        ReducedDensityMatrixDiagonalIterator(SparseVector<N> const& data, std::vector<bool> mask) :
-            internalsVariant(Internals<N>{.end = data.end(), .it = data.begin(), .reductionQubits = getMask<N>(mask)}) {}
+        ReducedDensityMatrixDiagonalIterator(MatrixOfVectors<N> const& data, std::vector<bool> const& mask) :
+            internalsVariant(Internals<N>{.data = data, .reductionQubits = getMask<N>(mask), .vectorIterator = data.cbegin(), .it = data[0].cbegin()}) {}
 
         std::optional<Value> next() {
             return std::visit([&](auto& internals) { return nextImpl(internals); }, internalsVariant);
         }
 
     private:
-        template <std::uint64_t N>
-        static BasisVector<N> getMask(std::vector<bool> v) {
-            BasisVector<N> mask;
-            for (std::uint64_t i = 0; i < v.size(); ++i) {
-                mask.set(i, v[i]);
-            }
-            return mask;
-        }
-
         template <typename Internals>
         std::optional<Value> nextImpl(Internals& internals) {
-            if (internals.it == internals.end) {
+            if (internals.vectorIterator == internals.data.end()) {
                 return std::nullopt;
             }
             
+            assert(internals.it != internals.vectorIterator->end());
+
             Value result = Value(internals.it->ket.pext(internals.reductionQubits), std::norm(internals.it->amplitude));
 
-            ++internals.it;
+            if (std::next(internals.it) != internals.vectorIterator->end()) {
+                ++internals.it;
+            } else {
+                ++internals.vectorIterator;
+                internals.it = internals.vectorIterator->begin();
+            }
 
             return result;
         }
 
         template <std::uint64_t N>
         struct Internals {
-            typename SparseVector<N>::const_iterator end;
-            typename SparseVector<N>::const_iterator it;
+            MatrixOfVectors<N> const& data;
             BasisVector<N> reductionQubits;
+            typename MatrixOfVectors<N>::const_iterator vectorIterator;
+            typename SparseVector<N>::const_iterator it;
         };
 
         std::variant<Internals<64UL>, Internals<128UL>> internalsVariant;
     };
 
 public:
-    ReducedDensityMatrixIterator getReducedDensityMatrixIterator(std::vector<bool> qubits) const {
+    ReducedDensityMatrixIterator getReducedDensityMatrixIterator(std::vector<bool> qubits) {
         assert(isConsistent());
-        assert(std::ranges::find_if(qubits.rbegin(), qubits.rend(), std::identity{}) - qubits.rend() < 128); // FIXME
+        assert(std::distance(std::ranges::find_if(qubits.rbegin(), qubits.rend(), std::identity{}), qubits.rend()) < 128); // FIXME
 
-        return std::visit([&](auto&& x) {
-            return ReducedDensityMatrixIterator(x, sizes, qubits);
+        return std::visit([&](auto& data) {
+            auto desiredSortIndices = ~getMask<std::remove_reference<decltype(data)>::type::value_type::value_type::MAX_NUMBER_OF_BITS>(qubits);
+            std::for_each(data.begin(), data.end(), [&](auto& v) {
+                sortSparseVector(v, currentSortIndices.cast<std::remove_reference<decltype(data)>::type::value_type::value_type::MAX_NUMBER_OF_BITS>(), desiredSortIndices);
+            });
+
+            currentSortIndices = ~getMask<128>(qubits); // FIXME
+
+            return ReducedDensityMatrixIterator(data, qubits);
         }, dataVariant);
     }
 
-    ReducedDensityMatrixDiagonalIterator getReducedDensityMatrixDiagonalIterator(std::vector<bool> qubits) const {
+    ReducedDensityMatrixDiagonalIterator getReducedDensityMatrixDiagonalIterator(std::vector<bool> const& qubits) const {
         assert(isConsistent());
-        assert(std::ranges::find_if(qubits.rbegin(), qubits.rend(), std::identity{}) - qubits.rend() < 128); // FIXME
+        assert(std::distance(std::ranges::find_if(qubits.rbegin(), qubits.rend(), std::identity{}), qubits.rend()) < 128); // FIXME
 
-        return std::visit([&](auto&& x) {
-            return ReducedDensityMatrixDiagonalIterator(x, qubits);
+        return std::visit([&](auto const& data) {
+            return ReducedDensityMatrixDiagonalIterator(data, qubits);
         }, dataVariant);
     }
 
     Matrix getReducedDensityMatrix(std::vector<bool> const& mask) {
-        auto popcount = std::ranges::count_if(mask, [](auto x) { return x; });
+        auto popcount = std::ranges::count_if(mask, std::identity{});
 
         assert(popcount > 0 && popcount < 64);
 
@@ -395,7 +408,20 @@ public:
                 m.add(j, i, std::conj(v));
             }
         }
+
+        // TODO: assert trace == 1.
+
         return m;
+    }
+
+    Matrix getReducedDensityMatrixFromIndices(std::initializer_list<std::uint64_t> const& qubits) {
+        std::vector<bool> mask;
+        for (auto i: qubits) {
+            mask.resize(std::max(mask.size(), i + 1), false);
+            mask[i] = true;
+        }
+
+        return getReducedDensityMatrix(mask);
     }
 
     std::vector<double> getReducedDensityMatrixDiagonal(std::vector<bool> const& mask) {
@@ -417,41 +443,11 @@ public:
         return result;
     }
 
-    // Matrix getMatrixOfVectors() const {
-    //     return std::visit([&](auto const& data) {
-    //         Matrix m(sizes.size(), 1UL << getNumberOfQubits(???));
-
-    //         auto it = data.cbegin();
-    //         for (std::uint64_t i = 0; i < sizes.size(); ++i) {
-    //             for (std::uint64_t x = 0; x < sizes[i]; ++x) {
-    //                 assert(it != data.cend());
-    //                 std::uint64_t j = it->first.toUInt64();
-    //                 m.set(i, j, it->second);
-    //                 ++it;
-    //             }
-    //         }
-    //         return m;
-    //     }, dataVariant);
-    // }
-
 private:
-    static std::variant<SparseVector<64>, SparseVector<128>> initDataVariant(std::uint64_t n) {
-        if (n <= 64) {
-            return SparseVector<64>{{BasisVector<64>{}, 1.}};
-        }
-        
-        if (n <= 128) {
-            return SparseVector<128>{{BasisVector<128>{}, 1.}};
-        }
-
-        throw std::runtime_error("Cannot handle this many qubits in this version of QX-simulator");
-    }
-
     bool isConsistent() const;
 
     BasisVector<128> currentSortIndices;
-    std::variant<SparseVector<64>, SparseVector<128>> dataVariant;
-    Sizes sizes;
+    std::variant<MatrixOfVectors<64>, MatrixOfVectors<128>> dataVariant;
     Hashes hashes;
 };
 

--- a/include/superpositeur/SparseVectorSort.hpp
+++ b/include/superpositeur/SparseVectorSort.hpp
@@ -104,7 +104,7 @@ void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumber
         return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
     }));
 
-    assert(currentSortIndices & desiredSortIndices == currentSortIndices);
+    assert((currentSortIndices & desiredSortIndices) == currentSortIndices);
 
     auto sortIndicesToAdd = (~currentSortIndices) & desiredSortIndices;
 

--- a/include/superpositeur/SparseVectorSort.hpp
+++ b/include/superpositeur/SparseVectorSort.hpp
@@ -1,151 +1,235 @@
 #include "superpositeur/Common.hpp"
 #include "oneapi/tbb/parallel_invoke.h"
 #include <algorithm>
+#include <chrono>
+#include <iostream>
 
 namespace superpositeur {
+
+// std::vector<It> breakPoints;
+// breakPoints.push_back(data.begin());
+// auto it = data.begin();
+// while (it != data.end()) {
+//     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
+//     if (adjacent == data.end()) {
+//         break;
+//     }
+//     ++adjacent;
+//     breakPoints.push_back(adjacent);
+//     it = adjacent;
+// }
+// breakPoints.push_back(data.end());
+
+// using ItIt = std::vector<It>::iterator;
+// std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
+//     auto dist = std::distance(begin, end);
+
+//     if (dist < 2) {
+//         return;
+//     }
+
+//     auto mid = std::next(begin, dist / 2);
+
+//     oneapi::tbb::parallel_invoke(
+//         [&process, begin, mid]{ process(begin, mid); },
+//         [&process, mid, end]{ process(mid, end); }
+//     );
+
+//     // process(begin, mid);
+//     // process(mid, end);
+    
+//     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
+// };
+
+// process(breakPoints.begin(), std::next(breakPoints.end(), -1));
+
+
+template <std::uint64_t MaxNumberOfQubits>
+void removeSortIndicesImpl(typename SparseVector<MaxNumberOfQubits>::iterator begin, typename SparseVector<MaxNumberOfQubits>::iterator end, BasisVector<MaxNumberOfQubits> sortIndicesToRemove, BasisVector<MaxNumberOfQubits> targetSortIndices) {
+    auto dist = std::distance(begin, end);
+    
+#ifndef NDEBUG
+    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 2;
+    constexpr std::int64_t SEQUENTIAL_LIMIT = 2;
+#else
+    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 25000;
+    constexpr std::int64_t SEQUENTIAL_LIMIT = 200;
+#endif
+    if (dist < SEQUENTIAL_LIMIT) {
+        std::sort(begin, end, [targetSortIndices](auto left, auto right) { return (left.ket & targetSortIndices) < (right.ket & targetSortIndices); });
+        return;
+    }
+
+    auto mid = std::next(begin, dist / 2);
+    auto current = (mid->ket & sortIndicesToRemove);
+    auto other = std::find_if(mid, end, [current, sortIndicesToRemove](auto x) { return (x.ket & sortIndicesToRemove) > current; });
+    if (other == end) {
+        // Normally this would use a reverse iterator.
+        other = mid;
+        do {
+            --other;
+            if ((other->ket & sortIndicesToRemove) < current) {
+                break;
+            }
+        } while (other != begin);
+
+        if ((other->ket & sortIndicesToRemove) >= current) {
+            return;
+        }
+
+        ++other;
+    }
+
+    if (std::distance(begin, other) > MIN_PARALLEL_PROBLEM_SIZE && std::distance(other, end) > MIN_PARALLEL_PROBLEM_SIZE) {
+        oneapi::tbb::parallel_invoke(
+            [begin, other, sortIndicesToRemove, targetSortIndices]{ removeSortIndicesImpl(begin, other, sortIndicesToRemove, targetSortIndices); },
+            [other, end, sortIndicesToRemove, targetSortIndices]{ removeSortIndicesImpl(other, end, sortIndicesToRemove, targetSortIndices); }
+        );
+    } else {
+        removeSortIndicesImpl(begin, other, sortIndicesToRemove, targetSortIndices);
+        removeSortIndicesImpl(other, end, sortIndicesToRemove, targetSortIndices);
+    }
+    
+    std::inplace_merge(begin, other, end, [targetSortIndices](auto left, auto right) { return (left.ket & targetSortIndices) < (right.ket & targetSortIndices); });
+}
+
+
+template <std::uint64_t MaxNumberOfQubits>
+void removeSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> sortIndicesToRemove) {
+    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
+        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
+    }));
+
+    assert((sortIndicesToRemove & currentSortIndices) == sortIndicesToRemove);
+
+    if (sortIndicesToRemove.empty()) {
+        return;
+    }
+
+    auto startTime = std::chrono::steady_clock::now();
+
+    auto targetSortIndices = currentSortIndices ^ sortIndicesToRemove;
+
+    removeSortIndicesImpl(data.begin(), data.end(), sortIndicesToRemove, targetSortIndices);
+    
+    auto endTime = std::chrono::steady_clock::now();
+
+    INSTRU << "removeSortIndices," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << "," << currentSortIndices << "," << sortIndicesToRemove << std::endl;
+
+    assert(std::is_sorted(data.begin(), data.end(), [targetSortIndices](auto const left, auto const right) {
+        return (left.ket & targetSortIndices) < (right.ket & targetSortIndices);
+    }));
+}
+
+
+template <std::uint64_t MaxNumberOfQubits>
+void addSortIndexImpl(typename SparseVector<MaxNumberOfQubits>::iterator begin, typename SparseVector<MaxNumberOfQubits>::iterator end, std::uint64_t index, BasisVector<MaxNumberOfQubits> mask) {
+    auto dist = std::distance(begin, end);
+
+    if (dist <= 1) {
+        return;
+    }
+
+// #ifndef NDEBUG
+//     constexpr std::int64_t SEQUENTIAL_LIMIT = 2;
+// #else
+//     constexpr std::int64_t SEQUENTIAL_LIMIT = 5000;
+// #endif
+
+    // if (dist < SEQUENTIAL_LIMIT) {
+    //     auto it = begin;
+    //     while (it != end) {
+    //         auto current = it->ket & mask;
+    //         auto partitionEnd = std::find_if(it, end, [current, mask](auto x) { return (x.ket & mask) != current; });
+    //         std::stable_partition(it, partitionEnd, [index](auto x) { return !x.ket.test(index); }); // Slight optimization possible: if indices are contiguous, this gives the following partitionEnd?
+    //         it = partitionEnd;
+    //     }
+    //     return;
+    // }
+
+    auto mid = std::next(begin, dist / 2);
+    auto current = mid->ket & mask;
+    auto other = std::find_if(mid, end, [current, mask](auto x) { return (x.ket & mask) != current; });
+    if (other == end) {
+        // Normally this would use a reverse iterator.
+        other = mid;
+        do {
+            --other;
+            if ((other->ket & mask) != current) {
+                break;
+            }
+        } while (other != begin);
+
+        if ((other->ket & mask) == current) {
+            std::stable_partition(begin, end, [index](auto x) { return !x.ket.test(index); });
+            return;
+        }
+
+        ++other;
+    }
+
+#ifndef NDEBUG
+    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 2;
+#else
+    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 25000;
+#endif
+
+    if (std::distance(begin, other) > MIN_PARALLEL_PROBLEM_SIZE && std::distance(other, end) > MIN_PARALLEL_PROBLEM_SIZE) {
+        oneapi::tbb::parallel_invoke(
+            [begin, other, index, mask]{ addSortIndexImpl(begin, other, index, mask); },
+            [other, end, index, mask]{ addSortIndexImpl(other, end, index, mask); }
+        );
+    } else {
+        addSortIndexImpl(begin, other, index, mask);
+        addSortIndexImpl(other, end, index, mask);
+    }
+}
+
+template <std::uint64_t MaxNumberOfQubits>
+void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> sortIndicesToAdd) {
+    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
+        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
+    }));
+
+    assert((currentSortIndices & sortIndicesToAdd).empty());
+
+    auto startTime = std::chrono::steady_clock::now();
+
+    auto remainingSortIndicesToAdd = sortIndicesToAdd;
+    while (!remainingSortIndicesToAdd.empty()) {
+        auto index = MaxNumberOfQubits - 1 - remainingSortIndicesToAdd.countlZero();
+        assert(remainingSortIndicesToAdd.test(index));
+        remainingSortIndicesToAdd.set(index, false);
+
+        auto mask = (index + 1 < MaxNumberOfQubits) ? ((~BasisVector<MaxNumberOfQubits>()) << (index + 1)) : BasisVector<MaxNumberOfQubits>();
+        mask &= (currentSortIndices | sortIndicesToAdd);
+
+        addSortIndexImpl(data.begin(), data.end(), index, mask);
+    }
+
+    auto endTime = std::chrono::steady_clock::now();
+
+    INSTRU << "addSortIndices," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << "," << currentSortIndices << "," << sortIndicesToAdd << std::endl;
+
+    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices, sortIndicesToAdd](auto const left, auto const right) {
+        return (left.ket & (currentSortIndices | sortIndicesToAdd)) < (right.ket & (currentSortIndices | sortIndicesToAdd));
+    }));
+}
 
 template <std::uint64_t MaxNumberOfQubits>
 void sortSparseVector(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> desiredSortIndices) {
     assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
         return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
     }));
-    
-    auto commonSortIndices = currentSortIndices & desiredSortIndices;
+
+    // FIXME: if sortIndicesToRemove.countrZero() is too small, but non-zero, do regular sort instead?
+
     auto sortIndicesToRemove = currentSortIndices & (~desiredSortIndices);
+    removeSortIndices(data, currentSortIndices, sortIndicesToRemove);
+
+    auto commonSortIndices = currentSortIndices & desiredSortIndices;
     auto sortIndicesToAdd = (~currentSortIndices) & desiredSortIndices;
-
-    // FIXME: if sortIndicesToRemove.countrZero() is too small, do regular sort instead?
-
-    if (!sortIndicesToRemove.empty()) {
-        using It = SparseVector<MaxNumberOfQubits>::iterator;
-        std::function<void(It, It)> removeIndices = [&removeIndices, sortIndicesToRemove, commonSortIndices](It begin, It end) {
-            auto dist = std::distance(begin, end);
-            
-#ifdef NDEBUG
-            constexpr std::uint64_t SEQUENTIAL_LIMIT = 2;
-#else
-            constexpr std::uint64_t SEQUENTIAL_LIMIT = 500;
-#endif
-            if (dist < SEQUENTIAL_LIMIT) {
-                std::sort(begin, end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
-                return;
-            }
-
-            auto mid = std::next(begin, dist / 2);
-            auto current = (mid->ket & sortIndicesToRemove);
-            auto other = std::find_if(mid, end, [current, sortIndicesToRemove](auto x) { return (x.ket & sortIndicesToRemove) > current; });
-            if (other == end) {
-                // Normally this would use a reverse iterator.
-                other = mid;
-                do {
-                    --other;
-                    if ((other->ket & sortIndicesToRemove) < current) {
-                        break;
-                    }
-                } while (other != begin);
-
-                if ((other->ket & sortIndicesToRemove) >= current) {
-                    return;
-                }
-
-                ++other;
-            }
-
-            oneapi::tbb::parallel_invoke(
-                [&removeIndices, begin, other]{ removeIndices(begin, other); },
-                [&removeIndices, other, end]{ removeIndices(other, end); }
-            );
-            
-            std::inplace_merge(begin, other, end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
-        };
-
-        removeIndices(data.begin(), data.end());
-    }
-
-
-    // using It = SparseVector<MaxNumberOfQubits>::iterator;
-
-
-    // std::vector<It> breakPoints;
-    // breakPoints.push_back(data.begin());
-    // auto it = data.begin();
-    // while (it != data.end()) {
-    //     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
-    //     if (adjacent == data.end()) {
-    //         break;
-    //     }
-    //     ++adjacent;
-    //     breakPoints.push_back(adjacent);
-    //     it = adjacent;
-    // }
-    // breakPoints.push_back(data.end());
-    
-    // using ItIt = std::vector<It>::iterator;
-    // std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
-    //     auto dist = std::distance(begin, end);
-
-    //     if (dist < 2) {
-    //         return;
-    //     }
-
-    //     auto mid = std::next(begin, dist / 2);
-
-    //     process(begin, mid);
-    //     process(mid, end);
-        
-    //     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
-    // };
-
-    // process(breakPoints.begin(), std::next(breakPoints.end(), -1));
-
-    // std::vector<It> breakPoints;
-    // breakPoints.push_back(data.begin());
-    // auto it = data.begin();
-    // while (it != data.end()) {
-    //     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
-    //     if (adjacent == data.end()) {
-    //         break;
-    //     }
-    //     ++adjacent;
-    //     breakPoints.push_back(adjacent);
-    //     it = adjacent;
-    // }
-    // breakPoints.push_back(data.end());
-    
-    // using ItIt = std::vector<It>::iterator;
-    // std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
-    //     auto dist = std::distance(begin, end);
-
-    //     if (dist < 2) {
-    //         return;
-    //     }
-
-    //     auto mid = std::next(begin, dist / 2);
-
-    //     process(begin, mid);
-    //     process(mid, end);
-        
-    //     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
-    // };
-
-    // process(breakPoints.begin(), std::next(breakPoints.end(), -1));
-
-    while (!sortIndicesToAdd.empty()) {
-        auto index = MaxNumberOfQubits - 1 - sortIndicesToAdd.countlZero();
-        assert(sortIndicesToAdd.test(index));
-        sortIndicesToAdd.set(index, false);
-
-        auto mask = (index + 1 < MaxNumberOfQubits) ? ((~BasisVector<MaxNumberOfQubits>()) << (index + 1)) : BasisVector<MaxNumberOfQubits>();
-        mask &= desiredSortIndices;
-
-        auto it = data.begin();
-        while (it != data.end()) {
-            auto current = it->ket & mask;
-            auto end = std::find_if(it, data.end(), [current, mask](auto x) { return (x.ket & mask) != current; });
-            std::stable_partition(it, end, [index](auto x) { return !x.ket.test(index); }); // Slight optimization possible: if indices are contiguous, this gives the following end?
-            it = end;
-        }
-    }
+    addSortIndices(data, commonSortIndices, sortIndicesToAdd);
 
     assert(std::is_sorted(data.begin(), data.end(), [desiredSortIndices](auto const left, auto const right) {
         return (left.ket & desiredSortIndices) < (right.ket & desiredSortIndices);

--- a/include/superpositeur/SparseVectorSort.hpp
+++ b/include/superpositeur/SparseVectorSort.hpp
@@ -1,96 +1,56 @@
 #include "superpositeur/Common.hpp"
-#include "oneapi/tbb/parallel_invoke.h"
 #include <algorithm>
+#include <execution>
 #include <chrono>
 #include <iostream>
 
 namespace superpositeur {
 
-// std::vector<It> breakPoints;
-// breakPoints.push_back(data.begin());
-// auto it = data.begin();
-// while (it != data.end()) {
-//     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
-//     if (adjacent == data.end()) {
-//         break;
-//     }
-//     ++adjacent;
-//     breakPoints.push_back(adjacent);
-//     it = adjacent;
-// }
-// breakPoints.push_back(data.end());
-
-// using ItIt = std::vector<It>::iterator;
-// std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
-//     auto dist = std::distance(begin, end);
-
-//     if (dist < 2) {
-//         return;
-//     }
-
-//     auto mid = std::next(begin, dist / 2);
-
-//     oneapi::tbb::parallel_invoke(
-//         [&process, begin, mid]{ process(begin, mid); },
-//         [&process, mid, end]{ process(mid, end); }
-//     );
-
-//     // process(begin, mid);
-//     // process(mid, end);
-    
-//     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
-// };
-
-// process(breakPoints.begin(), std::next(breakPoints.end(), -1));
-
-
 template <std::uint64_t MaxNumberOfQubits>
-void removeSortIndicesImpl(typename SparseVector<MaxNumberOfQubits>::iterator begin, typename SparseVector<MaxNumberOfQubits>::iterator end, BasisVector<MaxNumberOfQubits> sortIndicesToRemove, BasisVector<MaxNumberOfQubits> targetSortIndices) {
-    auto dist = std::distance(begin, end);
+void removeSortIndexImpl(SparseVector<MaxNumberOfQubits> &data, BasisVector<MaxNumberOfQubits> currentSortIndices, std::uint64_t indexToRemove) {
+    assert(currentSortIndices.test(indexToRemove));
     
-#ifndef NDEBUG
-    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 2;
-    constexpr std::int64_t SEQUENTIAL_LIMIT = 2;
-#else
-    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 25000;
-    constexpr std::int64_t SEQUENTIAL_LIMIT = 200;
-#endif
-    if (dist < SEQUENTIAL_LIMIT) {
-        std::sort(begin, end, [targetSortIndices](auto left, auto right) { return (left.ket & targetSortIndices) < (right.ket & targetSortIndices); });
-        return;
-    }
+    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
+        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
+    }));
 
-    auto mid = std::next(begin, dist / 2);
-    auto current = (mid->ket & sortIndicesToRemove);
-    auto other = std::find_if(mid, end, [current, sortIndicesToRemove](auto x) { return (x.ket & sortIndicesToRemove) > current; });
-    if (other == end) {
-        // Normally this would use a reverse iterator.
-        other = mid;
-        do {
-            --other;
-            if ((other->ket & sortIndicesToRemove) < current) {
-                break;
-            }
-        } while (other != begin);
+    auto outputSortIndices = currentSortIndices;
+    outputSortIndices.set(indexToRemove, false);
 
-        if ((other->ket & sortIndicesToRemove) >= current) {
-            return;
+    auto mask = (indexToRemove + 1 >= MaxNumberOfQubits) ? BasisVector<MaxNumberOfQubits>() : (((~BasisVector<MaxNumberOfQubits>()) << (indexToRemove + 1)) & currentSortIndices);
+
+    auto it = data.begin();
+    while (it != data.end()) {
+        auto mid = std::find_if(it, data.end(), [indexToRemove](auto x) { return x.ket.test(indexToRemove); });
+
+        assert((mid->ket & mask) >= (it->ket & mask));
+
+        if (mid == it) {
+            ++it;
+            continue;
         }
 
-        ++other;
+        if ((mid->ket & mask) != (it->ket & mask)) {
+            ++it;
+            continue;
+        }
+
+        auto end = std::find_if(mid, data.end(), [indexToRemove](auto x) { return !x.ket.test(indexToRemove); });
+
+        assert((std::next(end, -1)->ket & mask) >= (mid->ket & mask));
+
+        if ((std::next(end, -1)->ket & mask) == (mid->ket & mask)) {
+            assert(std::all_of(it, end, [mask, it](auto x) { return (x.ket & mask) == (it->ket & mask); }));
+
+            std::inplace_merge(it, mid, end, [outputSortIndices](auto left, auto right) { return (left.ket & outputSortIndices) < (right.ket & outputSortIndices); });
+        }
+
+        it = end;
     }
 
-    if (std::distance(begin, other) > MIN_PARALLEL_PROBLEM_SIZE && std::distance(other, end) > MIN_PARALLEL_PROBLEM_SIZE) {
-        oneapi::tbb::parallel_invoke(
-            [begin, other, sortIndicesToRemove, targetSortIndices]{ removeSortIndicesImpl(begin, other, sortIndicesToRemove, targetSortIndices); },
-            [other, end, sortIndicesToRemove, targetSortIndices]{ removeSortIndicesImpl(other, end, sortIndicesToRemove, targetSortIndices); }
-        );
-    } else {
-        removeSortIndicesImpl(begin, other, sortIndicesToRemove, targetSortIndices);
-        removeSortIndicesImpl(other, end, sortIndicesToRemove, targetSortIndices);
-    }
-    
-    std::inplace_merge(begin, other, end, [targetSortIndices](auto left, auto right) { return (left.ket & targetSortIndices) < (right.ket & targetSortIndices); });
+    assert(std::is_sorted(data.begin(), data.end(), [outputSortIndices](auto const left, auto const right) {
+        return (left.ket & outputSortIndices) < (right.ket & outputSortIndices);
+    }));
 }
 
 
@@ -108,80 +68,36 @@ void removeSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNum
 
     auto startTime = std::chrono::steady_clock::now();
 
-    auto targetSortIndices = currentSortIndices ^ sortIndicesToRemove;
+    auto remainingSortIndicesToRemove = sortIndicesToRemove;
+    auto removedSortIndices = BasisVector<MaxNumberOfQubits>();
+    assert((remainingSortIndicesToRemove | removedSortIndices) == sortIndicesToRemove);
+    while (!remainingSortIndicesToRemove.empty()) {
+        auto index = remainingSortIndicesToRemove.countrZero();
+        assert(remainingSortIndicesToRemove.test(index));
+        removeSortIndexImpl(data, currentSortIndices ^ removedSortIndices, index);
 
-    removeSortIndicesImpl(data.begin(), data.end(), sortIndicesToRemove, targetSortIndices);
+        remainingSortIndicesToRemove.set(index, false);
+        removedSortIndices.set(index);
+        assert((remainingSortIndicesToRemove | removedSortIndices) == sortIndicesToRemove);
+    }
     
     auto endTime = std::chrono::steady_clock::now();
 
     INSTRU << "removeSortIndices," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << "," << currentSortIndices << "," << sortIndicesToRemove << std::endl;
 
-    assert(std::is_sorted(data.begin(), data.end(), [targetSortIndices](auto const left, auto const right) {
+    assert(std::is_sorted(data.begin(), data.end(), [targetSortIndices = currentSortIndices ^ sortIndicesToRemove](auto const left, auto const right) {
         return (left.ket & targetSortIndices) < (right.ket & targetSortIndices);
     }));
 }
 
-
 template <std::uint64_t MaxNumberOfQubits>
-void addSortIndexImpl(typename SparseVector<MaxNumberOfQubits>::iterator begin, typename SparseVector<MaxNumberOfQubits>::iterator end, std::uint64_t index, BasisVector<MaxNumberOfQubits> mask) {
-    auto dist = std::distance(begin, end);
-
-    if (dist <= 1) {
-        return;
-    }
-
-// #ifndef NDEBUG
-//     constexpr std::int64_t SEQUENTIAL_LIMIT = 2;
-// #else
-//     constexpr std::int64_t SEQUENTIAL_LIMIT = 5000;
-// #endif
-
-    // if (dist < SEQUENTIAL_LIMIT) {
-    //     auto it = begin;
-    //     while (it != end) {
-    //         auto current = it->ket & mask;
-    //         auto partitionEnd = std::find_if(it, end, [current, mask](auto x) { return (x.ket & mask) != current; });
-    //         std::stable_partition(it, partitionEnd, [index](auto x) { return !x.ket.test(index); }); // Slight optimization possible: if indices are contiguous, this gives the following partitionEnd?
-    //         it = partitionEnd;
-    //     }
-    //     return;
-    // }
-
-    auto mid = std::next(begin, dist / 2);
-    auto current = mid->ket & mask;
-    auto other = std::find_if(mid, end, [current, mask](auto x) { return (x.ket & mask) != current; });
-    if (other == end) {
-        // Normally this would use a reverse iterator.
-        other = mid;
-        do {
-            --other;
-            if ((other->ket & mask) != current) {
-                break;
-            }
-        } while (other != begin);
-
-        if ((other->ket & mask) == current) {
-            std::stable_partition(begin, end, [index](auto x) { return !x.ket.test(index); });
-            return;
-        }
-
-        ++other;
-    }
-
-#ifndef NDEBUG
-    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 2;
-#else
-    constexpr std::int64_t MIN_PARALLEL_PROBLEM_SIZE = 25000;
-#endif
-
-    if (std::distance(begin, other) > MIN_PARALLEL_PROBLEM_SIZE && std::distance(other, end) > MIN_PARALLEL_PROBLEM_SIZE) {
-        oneapi::tbb::parallel_invoke(
-            [begin, other, index, mask]{ addSortIndexImpl(begin, other, index, mask); },
-            [other, end, index, mask]{ addSortIndexImpl(other, end, index, mask); }
-        );
-    } else {
-        addSortIndexImpl(begin, other, index, mask);
-        addSortIndexImpl(other, end, index, mask);
+void addSortIndexImpl(SparseVector<MaxNumberOfQubits> &data, std::uint64_t index, BasisVector<MaxNumberOfQubits> mask) {
+    auto it = data.begin();
+    while (it != data.end()) {
+        auto current = it->ket & mask;
+        auto endPartition = std::find_if(it, data.end(), [current, mask](auto x) { return (x.ket & mask) != current; });
+        std::stable_partition(it, endPartition, [index](auto x) { return !x.ket.test(index); });
+        it = endPartition;
     }
 }
 
@@ -192,6 +108,10 @@ void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumber
     }));
 
     assert((currentSortIndices & sortIndicesToAdd).empty());
+
+    if (sortIndicesToAdd.empty()) {
+        return;
+    }
 
     auto startTime = std::chrono::steady_clock::now();
 
@@ -204,7 +124,7 @@ void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumber
         auto mask = (index + 1 < MaxNumberOfQubits) ? ((~BasisVector<MaxNumberOfQubits>()) << (index + 1)) : BasisVector<MaxNumberOfQubits>();
         mask &= (currentSortIndices | sortIndicesToAdd);
 
-        addSortIndexImpl(data.begin(), data.end(), index, mask);
+        addSortIndexImpl(data, index, mask);
     }
 
     auto endTime = std::chrono::steady_clock::now();

--- a/include/superpositeur/SparseVectorSort.hpp
+++ b/include/superpositeur/SparseVectorSort.hpp
@@ -1,0 +1,155 @@
+#include "superpositeur/Common.hpp"
+#include "oneapi/tbb/parallel_invoke.h"
+#include <algorithm>
+
+namespace superpositeur {
+
+template <std::uint64_t MaxNumberOfQubits>
+void sortSparseVector(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> desiredSortIndices) {
+    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
+        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
+    }));
+    
+    auto commonSortIndices = currentSortIndices & desiredSortIndices;
+    auto sortIndicesToRemove = currentSortIndices & (~desiredSortIndices);
+    auto sortIndicesToAdd = (~currentSortIndices) & desiredSortIndices;
+
+    // FIXME: if sortIndicesToRemove.countrZero() is too small, do regular sort instead?
+
+    if (!sortIndicesToRemove.empty()) {
+        using It = SparseVector<MaxNumberOfQubits>::iterator;
+        std::function<void(It, It)> removeIndices = [&removeIndices, sortIndicesToRemove, commonSortIndices](It begin, It end) {
+            auto dist = std::distance(begin, end);
+            
+#ifdef NDEBUG
+            constexpr std::uint64_t SEQUENTIAL_LIMIT = 2;
+#else
+            constexpr std::uint64_t SEQUENTIAL_LIMIT = 500;
+#endif
+            if (dist < SEQUENTIAL_LIMIT) {
+                std::sort(begin, end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
+                return;
+            }
+
+            auto mid = std::next(begin, dist / 2);
+            auto current = (mid->ket & sortIndicesToRemove);
+            auto other = std::find_if(mid, end, [current, sortIndicesToRemove](auto x) { return (x.ket & sortIndicesToRemove) > current; });
+            if (other == end) {
+                // Normally this would use a reverse iterator.
+                other = mid;
+                do {
+                    --other;
+                    if ((other->ket & sortIndicesToRemove) < current) {
+                        break;
+                    }
+                } while (other != begin);
+
+                if ((other->ket & sortIndicesToRemove) >= current) {
+                    return;
+                }
+
+                ++other;
+            }
+
+            oneapi::tbb::parallel_invoke(
+                [&removeIndices, begin, other]{ removeIndices(begin, other); },
+                [&removeIndices, other, end]{ removeIndices(other, end); }
+            );
+            
+            std::inplace_merge(begin, other, end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
+        };
+
+        removeIndices(data.begin(), data.end());
+    }
+
+
+    // using It = SparseVector<MaxNumberOfQubits>::iterator;
+
+
+    // std::vector<It> breakPoints;
+    // breakPoints.push_back(data.begin());
+    // auto it = data.begin();
+    // while (it != data.end()) {
+    //     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
+    //     if (adjacent == data.end()) {
+    //         break;
+    //     }
+    //     ++adjacent;
+    //     breakPoints.push_back(adjacent);
+    //     it = adjacent;
+    // }
+    // breakPoints.push_back(data.end());
+    
+    // using ItIt = std::vector<It>::iterator;
+    // std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
+    //     auto dist = std::distance(begin, end);
+
+    //     if (dist < 2) {
+    //         return;
+    //     }
+
+    //     auto mid = std::next(begin, dist / 2);
+
+    //     process(begin, mid);
+    //     process(mid, end);
+        
+    //     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
+    // };
+
+    // process(breakPoints.begin(), std::next(breakPoints.end(), -1));
+
+    // std::vector<It> breakPoints;
+    // breakPoints.push_back(data.begin());
+    // auto it = data.begin();
+    // while (it != data.end()) {
+    //     auto adjacent = std::adjacent_find(it, data.end(), [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) > (right.ket & commonSortIndices); });
+    //     if (adjacent == data.end()) {
+    //         break;
+    //     }
+    //     ++adjacent;
+    //     breakPoints.push_back(adjacent);
+    //     it = adjacent;
+    // }
+    // breakPoints.push_back(data.end());
+    
+    // using ItIt = std::vector<It>::iterator;
+    // std::function<void(ItIt, ItIt)> process = [&process, commonSortIndices](ItIt begin, ItIt end) {
+    //     auto dist = std::distance(begin, end);
+
+    //     if (dist < 2) {
+    //         return;
+    //     }
+
+    //     auto mid = std::next(begin, dist / 2);
+
+    //     process(begin, mid);
+    //     process(mid, end);
+        
+    //     std::inplace_merge(*begin, *mid, *end, [commonSortIndices](auto left, auto right) { return (left.ket & commonSortIndices) < (right.ket & commonSortIndices); });
+    // };
+
+    // process(breakPoints.begin(), std::next(breakPoints.end(), -1));
+
+    while (!sortIndicesToAdd.empty()) {
+        auto index = MaxNumberOfQubits - 1 - sortIndicesToAdd.countlZero();
+        assert(sortIndicesToAdd.test(index));
+        sortIndicesToAdd.set(index, false);
+
+        auto mask = (index + 1 < MaxNumberOfQubits) ? ((~BasisVector<MaxNumberOfQubits>()) << (index + 1)) : BasisVector<MaxNumberOfQubits>();
+        mask &= desiredSortIndices;
+
+        auto it = data.begin();
+        while (it != data.end()) {
+            auto current = it->ket & mask;
+            auto end = std::find_if(it, data.end(), [current, mask](auto x) { return (x.ket & mask) != current; });
+            std::stable_partition(it, end, [index](auto x) { return !x.ket.test(index); }); // Slight optimization possible: if indices are contiguous, this gives the following end?
+            it = end;
+        }
+    }
+
+    assert(std::is_sorted(data.begin(), data.end(), [desiredSortIndices](auto const left, auto const right) {
+        return (left.ket & desiredSortIndices) < (right.ket & desiredSortIndices);
+    }));
+}
+
+}

--- a/include/superpositeur/SparseVectorSort.hpp
+++ b/include/superpositeur/SparseVectorSort.hpp
@@ -3,62 +3,174 @@
 #include <execution>
 #include <chrono>
 #include <iostream>
+#include <deque>
 
 namespace superpositeur {
+
+template <std::uint64_t MaxNumberOfQubits>
+bool isSortedOnIndices(typename SparseVector<MaxNumberOfQubits>::iterator begin, typename SparseVector<MaxNumberOfQubits>::iterator end, BasisVector<MaxNumberOfQubits> indices) {
+    return std::is_sorted(begin, end, [indices](auto const left, auto const right) {
+        return (left.ket & indices) < (right.ket & indices);
+    });
+}
+
+template <typename Iterator, typename Comp, typename Predicate>
+Iterator inplace_merge_aslongas(Iterator begin, Iterator mid, Comp&& comp, Predicate&& pred) {
+    auto end = mid;
+    while (pred(end)) {
+        ++end;
+    }
+
+    std::inplace_merge(begin, mid, end, comp);
+
+    return end;
+}
+
+template <typename Iterator, typename Comp, typename Predicate>
+Iterator inplace_merge_aslongas_experimental(Iterator begin, Iterator mid, Comp&& comp, Predicate&& pred) {
+    std::deque<typename Iterator::value> buffer;
+    auto write = begin;
+    auto second = mid;
+    while (pred(write)) {
+        assert(static_cast<int64_t>(buffer.size()) <= std::distance(begin, mid));
+        assert(write <= second);
+
+        if (buffer.empty()) {
+            if (!pred(second) || comp(*write, *second)) {
+                ++write;
+                continue;
+            }
+
+            if (write < mid) {
+                buffer.push_back(*write);
+            }
+
+            *write = *second;
+            ++write;
+            ++second;
+            continue;
+        }
+
+        if (write >= mid) {
+            if (!pred(second)) {
+                for (auto x: buffer) {
+                    *write = x;
+                    ++write;
+                }
+                buffer.clear();
+                break;
+            }
+
+            if (comp(buffer.front(), *second)) {
+                *write = buffer.front();
+                buffer.pop_front();
+                ++write;
+            } else {
+                *write = *second;
+                ++write;
+            }
+        } else {
+            if (!pred(second)) {
+                for (auto toPush = write; write != mid; ++write) {
+                    buffer.push_back(*toPush);
+                }
+
+                assert(static_cast<int64_t>(buffer.size()) == std::distance(write, second));
+                while (!buffer.empty()) {
+                    assert(!pred(write));
+                    *write = buffer.front();
+                    buffer.pop_front();
+                    ++write;
+                }
+                break;
+            }
+
+            auto min = std::min({ *write, *second, buffer.front() }, comp);
+            
+            if (!comp(min, second) && !comp(second, min)) {
+                buffer.push_back(*write);
+                *write = *second;
+                ++write;
+                ++second;
+            } else if (!comp(min, write) && !comp(write, min)) {
+                if (write == second) {
+                    ++second;
+                }
+                ++write;
+            } else {
+                buffer.push_back(*write);
+                *write = buffer.front();
+                buffer.pop_front();
+                ++write;
+            }
+        }
+    }
+
+    return write;
+}
 
 template <std::uint64_t MaxNumberOfQubits>
 void removeSortIndexImpl(SparseVector<MaxNumberOfQubits> &data, BasisVector<MaxNumberOfQubits> currentSortIndices, std::uint64_t indexToRemove) {
     assert(currentSortIndices.test(indexToRemove));
     
-    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
-        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), currentSortIndices));
 
     auto outputSortIndices = currentSortIndices;
     outputSortIndices.set(indexToRemove, false);
 
-    auto mask = (indexToRemove + 1 >= MaxNumberOfQubits) ? BasisVector<MaxNumberOfQubits>() : (((~BasisVector<MaxNumberOfQubits>()) << (indexToRemove + 1)) & currentSortIndices);
+    // auto mask = (indexToRemove + 1 >= MaxNumberOfQubits) ? BasisVector<MaxNumberOfQubits>() : (((~BasisVector<MaxNumberOfQubits>()) << (indexToRemove + 1)) & currentSortIndices);
+    // assert(isSortedOnIndices(data.begin(), data.end(), mask));
 
-    auto it = data.begin();
+    // auto it = data.begin();
+    // while (it != data.end()) {
+    //     auto currentMask = it->ket & mask;
+        
+    //     if (it->ket.test(indexToRemove)) {
+    //         it = std::find_if(it, data.end(), [mask, currentMask, indexToRemove](auto x) { return (x.ket & mask) != currentMask && !x.ket.test(indexToRemove); });
+    //         continue;
+    //     }
+        
+    //     auto one = std::find_if(it, data.end(), [indexToRemove](auto x) { return x.ket.test(indexToRemove); });
+
+    //     if (one == data.end() || (one->ket & mask) != currentMask) {
+    //         it = one;
+    //         continue;
+    //     }
+
+    //     assert(std::all_of(it, std::next(one), [mask, currentMask](auto x) { return (x.ket & mask) == currentMask; }));
+    //     assert(isSortedOnIndices(it, one, outputSortIndices));
+
+    //     it = inplace_merge_aslongas(it, one, [outputSortIndices](auto left, auto right) { return (left.ket & outputSortIndices) < (right.ket & outputSortIndices); }, [&data, mask, currentMask](auto x) { return x != data.end() && (x->ket & mask) == currentMask; });
+    // }
+
+    auto it = std::find_if(data.begin(), data.end(), [indexToRemove](auto x) { return !x.ket.test(indexToRemove); });
     while (it != data.end()) {
+        assert(!it->ket.test(indexToRemove));
         auto mid = std::find_if(it, data.end(), [indexToRemove](auto x) { return x.ket.test(indexToRemove); });
-
-        assert((mid->ket & mask) >= (it->ket & mask));
-
-        if (mid == it) {
-            ++it;
-            continue;
-        }
-
-        if ((mid->ket & mask) != (it->ket & mask)) {
-            ++it;
-            continue;
-        }
-
         auto end = std::find_if(mid, data.end(), [indexToRemove](auto x) { return !x.ket.test(indexToRemove); });
 
-        assert((std::next(end, -1)->ket & mask) >= (mid->ket & mask));
+        assert(end == data.end() || ((std::next(end, -1)->ket & outputSortIndices) < (end->ket & outputSortIndices)));
 
-        if ((std::next(end, -1)->ket & mask) == (mid->ket & mask)) {
-            assert(std::all_of(it, end, [mask, it](auto x) { return (x.ket & mask) == (it->ket & mask); }));
+        if (mid == data.end() || mid == end) {
+            it = end;
+            continue;
+        }
 
+        if ((mid->ket & outputSortIndices) < (std::next(mid, -1)->ket & outputSortIndices)) {
+            // FIXME: ranges can be smaller
             std::inplace_merge(it, mid, end, [outputSortIndices](auto left, auto right) { return (left.ket & outputSortIndices) < (right.ket & outputSortIndices); });
         }
 
         it = end;
     }
 
-    assert(std::is_sorted(data.begin(), data.end(), [outputSortIndices](auto const left, auto const right) {
-        return (left.ket & outputSortIndices) < (right.ket & outputSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), outputSortIndices));
 }
 
 
 template <std::uint64_t MaxNumberOfQubits>
 void removeSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> sortIndicesToRemove) {
-    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
-        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), currentSortIndices));
 
     assert((sortIndicesToRemove & currentSortIndices) == sortIndicesToRemove);
 
@@ -79,9 +191,7 @@ void removeSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNum
 
     INSTRU << "removeSortIndices," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << "," << currentSortIndices << "," << sortIndicesToRemove << std::endl;
 
-    assert(std::is_sorted(data.begin(), data.end(), [targetSortIndices = currentSortIndices](auto const left, auto const right) {
-        return (left.ket & targetSortIndices) < (right.ket & targetSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), currentSortIndices));
 }
 
 template <std::uint64_t MaxNumberOfQubits>
@@ -100,9 +210,7 @@ void addSortIndexImpl(SparseVector<MaxNumberOfQubits> &data, std::uint64_t index
 
 template <std::uint64_t MaxNumberOfQubits>
 void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> desiredSortIndices) {
-    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
-        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), currentSortIndices));
 
     assert((currentSortIndices & desiredSortIndices) == currentSortIndices);
 
@@ -125,16 +233,12 @@ void addSortIndices(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumber
 
     INSTRU << "addSortIndices," << data.size() << "," << std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count() << "," << currentSortIndices << "," << sortIndicesToAdd << std::endl;
 
-    assert(std::is_sorted(data.begin(), data.end(), [desiredSortIndices](auto const left, auto const right) {
-        return (left.ket & desiredSortIndices) < (right.ket & desiredSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), desiredSortIndices));
 }
 
 template <std::uint64_t MaxNumberOfQubits>
 void sortSparseVector(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumberOfQubits> currentSortIndices, BasisVector<MaxNumberOfQubits> desiredSortIndices) {
-    assert(std::is_sorted(data.begin(), data.end(), [currentSortIndices](auto const left, auto const right) {
-        return (left.ket & currentSortIndices) < (right.ket & currentSortIndices);
-    }));
+    assert(isSortedOnIndices<MaxNumberOfQubits>(data.begin(), data.end(), currentSortIndices));
 
     // FIXME: if sortIndicesToRemove.countrZero() is too small, but non-zero, do regular sort instead?
 
@@ -144,9 +248,7 @@ void sortSparseVector(SparseVector<MaxNumberOfQubits>& data, BasisVector<MaxNumb
     auto commonSortIndices = currentSortIndices & desiredSortIndices;
     addSortIndices(data, commonSortIndices, desiredSortIndices);
 
-    assert(std::is_sorted(data.begin(), data.end(), [desiredSortIndices](auto const left, auto const right) {
-        return (left.ket & desiredSortIndices) < (right.ket & desiredSortIndices);
-    }));
+    assert(isSortedOnIndices(data.begin(), data.end(), desiredSortIndices));
 }
 
 }

--- a/include/superpositeur/config/CompileTimeConfiguration.hpp
+++ b/include/superpositeur/config/CompileTimeConfiguration.hpp
@@ -4,7 +4,7 @@ namespace superpositeur {
 namespace config {
 
 // Absolute TOLerance for double comparison
-static constexpr double ATOL = 1e-12;
+static constexpr double ATOL = 1e-11;
 
 } // namespace config
 

--- a/include/superpositeur/utils/BitSet.hpp
+++ b/include/superpositeur/utils/BitSet.hpp
@@ -262,6 +262,20 @@ public:
 
         return result;
     }
+
+    std::uint64_t countrZero() const {
+        std::uint64_t result = 0;
+
+        for (std::uint64_t i = 0; i < STORAGE_SIZE; ++i) {
+            std::uint64_t partialCountrZero = std::countr_zero(data[i]);
+            result += partialCountrZero;
+            if (partialCountrZero < BITS_PER_UNIT) {
+                return result;
+            }
+        }
+
+        return result;
+    }
     
     inline std::uint64_t bitWidth() const {
         return NumberOfBits - countlZero();

--- a/include/superpositeur/utils/TaggedInteger.hpp
+++ b/include/superpositeur/utils/TaggedInteger.hpp
@@ -4,7 +4,7 @@ namespace superpositeur {
 namespace utils {
 
 template <typename T> struct TaggedInteger {
-    std::uint64_t value = 0;
+    explicit TaggedInteger(std::uint64_t x) : value(x) {}
 
     constexpr auto operator<=>(TaggedInteger const &other) const = default;
     
@@ -17,6 +17,8 @@ template <typename T> struct TaggedInteger {
     template <typename S>
     friend TaggedInteger<S> operator+(TaggedInteger<S> left,
                                       TaggedInteger<S> right);
+
+    std::uint64_t value = 0;
 };
 
 template <typename T>

--- a/src/superpositeur/SparseVectorSort.cpp
+++ b/src/superpositeur/SparseVectorSort.cpp
@@ -1,0 +1,1 @@
+#include "superpositeur/SparseVectorSort.hpp"

--- a/test/BitSetTest.cpp
+++ b/test/BitSetTest.cpp
@@ -149,6 +149,27 @@ TEST_F(BitSetTest, CountlZero) {
     EXPECT_EQ(BitSet<64>("11111").countlZero(), 59);
 }
 
+TEST_F(BitSetTest, CountrZero) {
+    BitSet<8576> victim;
+    victim.set(1);
+
+    EXPECT_EQ(victim.countrZero(), 1);
+    
+    victim.set(1, false);
+    EXPECT_EQ(victim.countrZero(), 8576);
+    
+    victim.set(14);
+    victim.set(1451);
+    victim.set(4452);
+    EXPECT_EQ(victim.countrZero(), 14);
+    
+    victim.set(14, false);
+
+    EXPECT_EQ(victim.countrZero(), 1451);
+
+    EXPECT_EQ(BitSet<64>("10100").countrZero(), 2);
+}
+
 TEST_F(BitSetTest, LeftShiftSmall) {
     BitSet<64> victim{"000010000010001"};
     EXPECT_EQ(victim << 0, victim);

--- a/test/BitSetTest.cpp
+++ b/test/BitSetTest.cpp
@@ -149,6 +149,45 @@ TEST_F(BitSetTest, CountlZero) {
     EXPECT_EQ(BitSet<64>("11111").countlZero(), 59);
 }
 
+TEST_F(BitSetTest, LeftShiftSmall) {
+    BitSet<64> victim{"000010000010001"};
+    EXPECT_EQ(victim << 0, victim);
+    EXPECT_EQ(victim << 1, BitSet<64>{"000100000100010"});
+    EXPECT_EQ(victim << 2, BitSet<64>{"001000001000100"});
+    EXPECT_EQ(victim << 14, BitSet<64>{"00001000001000100000000000000"});
+    EXPECT_EQ(victim << 15, BitSet<64>{"000010000010001000000000000000"});
+    EXPECT_EQ(victim << 63, BitSet<64>{"1000000000000000000000000000000000000000000000000000000000000000"});
+    EXPECT_EQ(victim << 64, BitSet<64>{"0000000000000000000000000000000000000000000000000000000000000000"});
+}
+
+TEST_F(BitSetTest, LeftShiftLarge) {
+    BitSet<512> victim;
+    victim.set(3);
+    victim.set(30);
+    victim.set(300);
+    EXPECT_EQ(victim << 0, victim);
+
+    BitSet<512> expected1;
+    expected1.set(4);
+    expected1.set(31);
+    expected1.set(301);
+
+    EXPECT_EQ(victim << 1, expected1);
+
+    BitSet<512> expected200;
+    expected200.set(203);
+    expected200.set(230);
+    expected200.set(500);
+
+    EXPECT_EQ(victim << 200, expected200);
+
+    BitSet<512> expected400;
+    expected400.set(403);
+    expected400.set(430);
+
+    EXPECT_EQ(victim << 400, expected400);
+}
+
 TEST_F(BitSetTest, Pext) {
     BitSet<384> victim;
     victim.set(345);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(superpositeur-test
     "${CMAKE_CURRENT_SOURCE_DIR}/MixedStateTest.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/MatrixTest.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/OperandPermutationTest.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/SparseVectorSortTest.cpp"
     ${generated_random_integration_tests}
 )
 

--- a/test/GivensRotationTest.cpp
+++ b/test/GivensRotationTest.cpp
@@ -13,17 +13,13 @@ TEST_F(MixedStateSimplifierTest, ApplyGivensRotation) {
     SparseVector<64> a = {{BV(0), 1.}, {BV(1), 1.}};
     SparseVector<64> b = {{BV(0), 1.}, {BV(1), 1.}};
 
-    std::uint64_t hashA = 0xDEADBEEF;
-    std::uint64_t hashB = 0xDEADBEEF;
+    std::uint64_t hashA = BV(0).hash() + BV(1).hash();
+    std::uint64_t hashB = BV(0).hash() + BV(1).hash();
 
-    std::span<KeyValue<64>> firstLine{a.begin(), a.end()};
-    std::span<KeyValue<64>> secondLine{b.begin(), b.end()};
-    applyGivensRotation(firstLine, hashA, secondLine, hashB);
+    applyGivensRotation(a, hashA, b, hashB);
 
-    EXPECT_EQ(a[0].ket, BV(0));
-    EXPECT_EQ(a[0].amplitude, 0.);
-    EXPECT_EQ(a[1].ket, BV(1));
-    EXPECT_EQ(a[1].amplitude, 0.);
+    EXPECT_TRUE(a.empty());
+    EXPECT_EQ(b.size(), 2);
     EXPECT_EQ(b[0].ket, BV(0));
     EXPECT_DOUBLE_EQ(b[0].amplitude.real(), std::sqrt(2));
     EXPECT_DOUBLE_EQ(b[0].amplitude.imag(), 0.);
@@ -34,7 +30,5 @@ TEST_F(MixedStateSimplifierTest, ApplyGivensRotation) {
     // EXPECT_EQ(hashA, 1);
     // EXPECT_EQ(hashB, 1); // FIXME
 }
-
-// FIXME: should fail / revert if keys are not identical in both rows.
 
 } // namespace  superpositeur

--- a/test/IntegrationTest.cpp
+++ b/test/IntegrationTest.cpp
@@ -8,7 +8,61 @@ namespace superpositeur {
 class IntegrationTest : public ::testing::Test {
 };
 
-TEST_F(IntegrationTest, Simple) {
+TEST_F(IntegrationTest, Nothing) {
+    MixedState s;
+
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({1}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({2}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({30}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 1}), Matrix({{1., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 32}), Matrix({{1., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({35, 32}), Matrix({{1., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+}
+
+TEST_F(IntegrationTest, X) {
+    MixedState s;
+
+    s(CircuitInstruction({ default_operations::X }, {QubitIndex(0)}));
+
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0}), Matrix({{0., 0.}, {0., 1.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 1}), Matrix({{0., 0., 0., 0.}, {0., 1., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 32}), Matrix({{0., 0., 0., 0.}, {0., 1., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+}
+
+TEST_F(IntegrationTest, XOn37) {
+    MixedState s;
+
+    s(CircuitInstruction({ default_operations::X }, {QubitIndex(37)}));
+
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 1}), Matrix({{1., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 37}), Matrix({{0., 0., 0., 0.}, {0., 0., 0., 0.}, {0., 0., 1., 0.}, {0., 0., 0., 0.}}));
+}
+
+TEST_F(IntegrationTest, H) {
+    MixedState s;
+
+    s(CircuitInstruction({ default_operations::H }, {QubitIndex(0)}));
+
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0}), Matrix({{.5, .5}, {.5, .5}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({1}), Matrix({{1., 0.}, {0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 1}), Matrix({{.5, .5, 0., 0.}, {.5, .5, 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({1, 0}), Matrix({{.5, .5, 0., 0.}, {.5, .5, 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+}
+
+TEST_F(IntegrationTest, MeasuredH) {
+    MixedState s;
+
+    s(CircuitInstruction({ default_operations::H }, {QubitIndex(0)}));
+    s(CircuitInstruction(default_operations::MEAS_Z, {QubitIndex(0)}));
+
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0}), Matrix({{.5, 0.}, {0., .5}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({0, 1}), Matrix({{.5, 0., 0., 0.}, {0., .5, 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+    EXPECT_EQ(s.getReducedDensityMatrixFromIndices({1, 0}), Matrix({{.5, 0., 0., 0.}, {0., .5, 0., 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}}));
+}
+
+TEST_F(IntegrationTest, SomeDepolarizingChannels) {
     MixedState s;
 
     s(CircuitInstruction({ default_operations::H }, {QubitIndex(0)}));
@@ -22,8 +76,6 @@ TEST_F(IntegrationTest, Simple) {
     s(CircuitInstruction(default_operations::DEPOLARIZING_CHANNEL(0.3), {QubitIndex(0)}));
     s(CircuitInstruction(default_operations::DEPOLARIZING_CHANNEL(0.3), {QubitIndex(1)}));
     s(CircuitInstruction({ default_operations::CNOT }, {QubitIndex(0), QubitIndex(1)}));
-
-    std::cout << s.getReducedDensityMatrix(std::vector<bool>(2, true)) << std::endl;
 }
 
 } // namespace  superpositeur

--- a/test/SparseVectorSortTest.cpp
+++ b/test/SparseVectorSortTest.cpp
@@ -12,7 +12,7 @@ public:
     V create(std::initializer_list<std::string> l) {
         V v;
         for (auto& s: l) {
-            v.emplace_back(B(s), 0.);
+            v.push_back({B(s), 0.});
         }
 
         return v;
@@ -159,6 +159,16 @@ TEST_F(SparseVectorSortTest, ThisThingCanAlsoCompletelySort) {
 
     check(victim, {"000000", "001100", "001111", "010100", "011000", "011111", "100111", "110000", "110111"});
 }
+
+// TEST_F(SparseVectorSortTest, SparseBug) {
+//     auto victim = create({"000000", "010000", "010100", "110000", "101100", "100111", "101111", "110111", "111111"});
+//     B current("100111"); 
+//     B desired("110011");
+
+//     sortSparseVector(victim, current, desired);
+
+//     check(victim, {"000000", "010000", "010100", "101100", "100111", "101111", "110000", "110111", "111111"});
+// }
 
 
 }

--- a/test/SparseVectorSortTest.cpp
+++ b/test/SparseVectorSortTest.cpp
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+
+#include "superpositeur/SparseVectorSort.hpp"
+
+namespace superpositeur {
+
+class SparseVectorSortTest : public ::testing::Test {
+public:
+    using V = SparseVector<64>;
+    using B = BasisVector<64>;
+
+    V create(std::initializer_list<std::string> l) {
+        V v;
+        for (auto& s: l) {
+            v.emplace_back(B(s), 0.);
+        }
+
+        return v;
+    }
+
+    void check(V victim, std::vector<std::string> l) {
+        ASSERT_EQ(victim.size(), l.size());
+
+        for (std::uint64_t i = 0; i < victim.size(); ++i) {
+            EXPECT_EQ(victim[i].amplitude, 0.) << "Index: " << i << std::endl;
+            EXPECT_EQ(victim[i].ket, B(l[i])) << "Index: " << i << std::endl;
+        }
+    }
+};
+
+TEST_F(SparseVectorSortTest, FullRemoveRightmost) {
+    auto victim = create({"000", "001", "010", "011", "100", "101", "110", "111"});
+    B current("111"); 
+    B desired("110");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullRemoveTwoRightmost) {
+    auto victim = create({"000", "001", "010", "011", "100", "101", "110", "111"});
+    B current("111"); 
+    B desired("100");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullRemoveLeftmost) {
+    auto victim = create({"000", "001", "010", "011", "100", "101", "110", "111"});
+    B current("111"); 
+    B desired("011");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "100", "001", "101", "010", "110", "011", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullRemoveTwoLeftmost) {
+    auto victim = create({"000", "001", "010", "011", "100", "101", "110", "111"});
+    B current("111"); 
+    B desired("001");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "010", "100", "110", "001", "011", "101", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullAddRightmost) {
+    auto victim = create({"000", "001", "010", "011", "100", "101", "110", "111"});
+    B current("110"); 
+    B desired("111");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullAddMiddle) {
+    auto victim = create({"000", "010", "001", "011", "100", "110", "101", "111"});
+    B current("101"); 
+    B desired("111");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullAddLeftmost) {
+    auto victim = create({"000", "100", "001", "101", "010", "110", "011", "111"});
+    B current("011"); 
+    B desired("111");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, FullAddRemove) {
+    auto victim = create({"000", "100", "001", "101", "010", "110", "011", "111"});
+    B current("011"); 
+    B desired("110");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "001", "010", "011", "100", "101", "110", "111"});
+}
+
+TEST_F(SparseVectorSortTest, NotFullAddRemove) {
+    auto victim = create({"000", "101", "010", "011", "111"});
+    B current("011"); 
+    B desired("110");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "010", "011", "101", "111"});
+}
+
+TEST_F(SparseVectorSortTest, NotFullAddRemoveDisjoint) {
+    auto victim = create({"000", "101", "010", "011", "111"});
+    B current("011"); 
+    B desired("100");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000", "010", "011", "101", "111"});
+}
+
+TEST_F(SparseVectorSortTest, LargerNotFullAddRemove) {
+    auto victim = create({"00000", "01000", "01010", "11000", "10110"});
+    B current("10111"); 
+    B desired("11101");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"00000", "01000", "01010", "10110", "11000"});
+}
+
+TEST_F(SparseVectorSortTest, EvenLargerNotFullAddRemove) {
+    auto victim = create({"000000", "010000", "010100", "110000", "101100", "100111", "101111", "110111", "111111"});
+    B current("100111"); 
+    B desired("110011");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000000", "010000", "010100", "101100", "100111", "101111", "110000", "110111", "111111"});
+}
+
+TEST_F(SparseVectorSortTest, ThisThingCanAlsoCompletelySort) {
+    // Radix sort.
+    
+    auto victim = create({"000000", "100111", "010100", "110000", "001100", "011000", "001111", "110111", "011111"});
+    B current("000000"); 
+    B desired("110011");
+
+    sortSparseVector(victim, current, desired);
+
+    check(victim, {"000000", "001100", "001111", "010100", "011000", "011111", "100111", "110000", "110111"});
+}
+
+
+}


### PR DESCRIPTION
- Sort the state vector based on which qubits a gate operates on
- Do this with a new adaptive sort algorithm, which leverages existing sort order to minimize operations
- Attempt was made to make this parallel, but back to sequential because parallel is not necessarily faster (memory-bound, single memory bus)
- Mixed state is stored as vector of vectors